### PR TITLE
update matrix exp

### DIFF
--- a/modules/utility/pyarchinit_matrix_exp.py
+++ b/modules/utility/pyarchinit_matrix_exp.py
@@ -76,11 +76,10 @@ class HarrisMatrix:
         with open(os.path.join(matrix_path, filename + '_tred.dot'), "w") as out, \
                 open(os.path.join(matrix_path, 'matrix_error.txt'), "w") as err:
             subprocess.Popen(['tred', dot_file],
-                             #shell=False,
+                             shell=False,
                              stdout=out,
-                             stderr=err)
-                             #startupinfo=si if Pyarchinit_OS_Utility.isWindows() 
-                             #else None)
+                             stderr=err,
+                             startupinfo=si if Pyarchinit_OS_Utility.isWindows()else None)
 
         tred_file = os.path.join(matrix_path, filename + '_tred.dot')
         g = Source.from_file(tred_file, format='svg')


### PR DESCRIPTION
piccola modifica ma su windows funziona correttamente con una versione qgis 64 bit standalone. su osgqo 23 bit il tred di graphiz sembra non funzionare